### PR TITLE
Fix: Correct grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@
 本项目可以部署到任何支持静态网页托管的服务上，例如 GitHub Pages 或 EdgeOne Pages。
 
 ### EdgeOne Pages 部署
-本项目已通过 EdgeOne Pages 部署。您可以通过以下临时 URL 访问：
-
-[(https://rovocli.edgeone.app)
+本项目已通过 EdgeOne Pages 部署。您可以通过以下临时 URL 访问：(https://rovocli.edgeone.app)
 
 如需永久链接，请在 EdgeOne Pages 控制台绑定自定义域名。
 


### PR DESCRIPTION
Moved the EdgeOne Pages temporary URL to be on the same line as the introductory text for better readability and grammatical correctness.